### PR TITLE
add AssemblyScript string implementation

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,0 +1,4 @@
+//! Module containing FFI utilities for mapping Rust/C ABI to the AssemblyScript
+//! ABI.
+
+pub mod string;

--- a/src/ffi/string.rs
+++ b/src/ffi/string.rs
@@ -1,0 +1,195 @@
+//! AssemblyScript string implementation.
+
+use std::{
+    alloc::{self, Layout, LayoutErr},
+    fmt::{self, Debug, Formatter},
+    mem,
+    ops::Deref,
+    slice,
+    string::FromUtf16Error,
+};
+
+/// Internal representation of an AssemblyScript string.
+///
+/// AssemblyScript strings are length prefixed utf-16 strings. That is, they
+/// are laid out in memory starting with a length `l` (usize is 32-bits in the
+/// `wasm32-*` targets) followd by `l` utf-16 `u16` code points.
+///
+/// `Inner` is declared as a generic struct in order to take advantage of the
+/// partial dynamically sized type (DST) support. For more information see:
+/// <https://doc.rust-lang.org/nomicon/exotic-sizes.html#dynamically-sized-types-dsts>
+#[repr(C)]
+struct Inner<T: ?Sized> {
+    len: usize,
+    buf: T,
+}
+
+/// A borrowed AssemblyScript string.
+///
+/// Dynamically sized types are not safe over FFI boundries, so it is important
+/// to only use `AscStr` (and not `AscString`) as exported and imported function
+/// parameter types.
+#[repr(transparent)]
+pub struct AscStr(Inner<[u16; 0]>);
+
+impl AscStr {
+    /// Converts the AssemblyScript string into a Rust `String`.
+    #[allow(unused)] // TODO(nlordell): Remove once it is used.
+    pub fn to_string(&self) -> Result<String, FromUtf16Error> {
+        String::from_utf16(&self.as_code_points())
+    }
+
+    /// Converts the AssemblyScript string into a Rust `String`, replacing
+    /// invalid data with the replacement character (`U+FFFD`).
+    pub fn to_string_lossy(&self) -> String {
+        String::from_utf16_lossy(&self.as_code_points())
+    }
+
+    /// Returns a slice of the utf-16 code points for this string.
+    fn as_code_points(&self) -> &[u16] {
+        unsafe { slice::from_raw_parts(&self.0.buf as *const _, self.0.len) }
+    }
+}
+
+impl Debug for AscStr {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Debug::fmt(&self.to_string_lossy(), f)
+    }
+}
+
+/// An AssemblyScript string.
+#[repr(transparent)]
+pub struct AscString(Inner<[u16]>);
+
+impl AscString {
+    /// Creates a new AssemblyScript string from a Rust string slice.
+    #[allow(unused)]
+    pub fn new(s: impl AsRef<str>) -> Box<Self> {
+        let s = s.as_ref();
+        let len = s.encode_utf16().count();
+        let mut string = unsafe { alloc_string(len).unwrap() };
+        string.0.len = len;
+        for (i, c) in s.encode_utf16().enumerate() {
+            string.0.buf[i] = c;
+        }
+
+        string
+    }
+
+    /// Returns a reference to a borrowed AssemblyScript string.
+    pub fn as_asc_str(&self) -> &AscStr {
+        unsafe { &*(&self.0.len as *const usize).cast::<AscStr>() }
+    }
+}
+
+impl Deref for AscString {
+    type Target = AscStr;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_asc_str()
+    }
+}
+
+impl Debug for AscString {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Debug::fmt(self.as_asc_str(), f)
+    }
+}
+
+/// A Rust dynamically sized type fat pointer.
+#[repr(C)]
+struct DstRef {
+    ptr: *const u8,
+    len: usize,
+}
+
+/// Returns the memory layout for an AssemblyScript string.
+fn string_layout(len: usize) -> Result<Layout, LayoutErr> {
+    let (layout, _) = Layout::new::<usize>().extend(Layout::array::<i16>(len)?)?;
+    // NOTE: Pad to alignment for C ABI compatibility. See
+    // <https://doc.rust-lang.org/std/alloc/struct.Layout.html#method.extend>
+    Ok(layout.pad_to_align())
+}
+
+/// Allocates an empty uninitialized AssemblyScript string with the
+/// specified length.
+unsafe fn alloc_string(len: usize) -> Result<Box<AscString>, LayoutErr> {
+    // NOTE: Rust only has partial DST support, so we need to use some unsafe
+    // magic to create a fat `Box` for a DST since there is currently no stable
+    // safe way to create one otherwise.
+    let string = mem::transmute(DstRef {
+        ptr: alloc::alloc(string_layout(len)?),
+        len,
+    });
+
+    Ok(string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_round_trip_str() {
+        let message = "Hello 🦀";
+        assert_eq!(AscString::new(message).to_string().unwrap(), message);
+    }
+
+    #[test]
+    fn string_has_c_layout() {
+        let string = AscString::new("1");
+        let layout = Layout::for_value(&*string);
+        assert_eq!(layout, string_layout(1).unwrap());
+
+        // NOTE: Also check that it matches the intrinsic Rust DST layout.
+        assert_eq!(
+            Layout::for_value(&*{
+                let inner: Box<Inner<[u16]>> = Box::new(Inner {
+                    len: 0,
+                    buf: [0; 5],
+                });
+                inner
+            }),
+            string_layout(5).unwrap()
+        );
+        assert_eq!(
+            Layout::for_value(&*{
+                let inner: Box<Inner<[u16]>> = Box::new(Inner {
+                    len: 0,
+                    buf: [0; 8],
+                });
+                inner
+            }),
+            string_layout(8).unwrap()
+        );
+    }
+
+    #[test]
+    fn string_has_length_set() {
+        let string = AscString::new("1");
+        assert_eq!(string.0.len, string.0.buf.len());
+    }
+
+    #[test]
+    fn dst_ref_layout() {
+        let inner: Box<Inner<[u16]>> = Box::new(Inner {
+            len: 0,
+            buf: [0; 5],
+        });
+
+        let inner_ptr = &inner.len as *const usize;
+        let inner_ref: DstRef = unsafe { mem::transmute(inner) };
+
+        assert_eq!(inner_ref.ptr, inner_ptr.cast::<u8>());
+        assert_eq!(inner_ref.len, 5);
+
+        mem::drop(unsafe { mem::transmute::<_, Box<Inner<[u16]>>>(inner_ref) });
+    }
+
+    #[test]
+    #[should_panic]
+    fn string_access_out_of_bounds() {
+        let string = AscString::new("1");
+        let _ = string.0.buf[1];
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,1 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+mod ffi;


### PR DESCRIPTION
This PR adds an AssemblyScript string implementation. This allows the subgraph library to send and receive strings from the Rust runtime.

### Test Plan

Added some unit tests to make sure that the `unsafe` logic is sound.