### PR TITLE
Add logger implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ description = "Write subgraph mappings in Rust 🦀"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+log = "0.4.11"

--- a/src/ffi/string.rs
+++ b/src/ffi/string.rs
@@ -111,9 +111,10 @@ fn string_layout(len: usize) -> Result<Layout, LayoutErr> {
 }
 
 /// A Rust dynamically sized type fat pointer.
-#[allow(dead_code)]
 struct DstRef {
+    #[allow(dead_code)]
     ptr: *const u8,
+    #[allow(dead_code)]
     len: usize,
 }
 

--- a/src/ffi/string.rs
+++ b/src/ffi/string.rs
@@ -67,7 +67,6 @@ pub struct AscString {
 
 impl AscString {
     /// Creates a new AssemblyScript string from a Rust string slice.
-    #[allow(unused)]
     pub fn new(s: impl AsRef<str>) -> Box<Self> {
         let s = s.as_ref();
         let len = s.encode_utf16().count();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,18 @@
 mod ffi;
+mod logger;
+
+pub use log;
+
+/// Module containing required Wasm exports.
+#[doc(hidden)]
+pub mod exports {
+    use crate::logger;
+
+    /// The Wasm start function. This gets set as the module's start function
+    /// during post-processing of the Wasm blob, since there is currently no
+    /// way to specify it in Rust at the moment.
+    #[export_name = "__subgraph_start"]
+    pub extern "C" fn start() {
+        logger::init();
+    }
+}

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,47 @@
+//! Module containing logger implementation.
+
+use crate::ffi::string::{AscStr, AscString};
+use log::{Level, LevelFilter, Log, Metadata, Record};
+
+/// The main logger implementation for the `log` facade crate.
+pub struct Logger;
+
+impl Log for Logger {
+    fn enabled(&self, _: &Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        let level = match record.level() {
+            Level::Error => ERROR,
+            Level::Warn => WARNING,
+            Level::Info => INFO,
+            Level::Debug | Level::Trace => DEBUG,
+        };
+        let message = AscString::new(record.args().to_string());
+
+        unsafe {
+            log(level, &message);
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+/// Initialize logging.
+pub fn init() {
+    static LOGGER: Logger = Logger;
+    log::set_logger(&LOGGER).unwrap();
+    log::set_max_level(LevelFilter::Debug);
+}
+
+const ERROR: u32 = 1;
+const WARNING: u32 = 2;
+const INFO: u32 = 3;
+const DEBUG: u32 = 4;
+
+#[link(wasm_import_module = "index")]
+extern "C" {
+    #[link_name = "log.log"]
+    fn log(level: u32, message: &AscStr);
+}


### PR DESCRIPTION
This PR adds a `log::Log` implementation that works with the standard `log` crate :tada:.

### Test Plan

This is currently largely untested. It requires a sample subgraph to make sure it would work as expected. That will come in a follow up PR.