### PR TITLE
Implement abort panic hook

### DIFF
--- a/src/abort.rs
+++ b/src/abort.rs
@@ -1,0 +1,41 @@
+//! Module implementing panic handler that calls the host's `abort` method.
+
+use crate::ffi::string::{AscStr, AscString};
+use std::panic;
+
+/// Sets the panic hook to use the host provided `abort` call.
+pub fn set_panic_hook() {
+    panic::set_hook(Box::new(|info| {
+        let (message, location) = if let Some(message) = info.payload().downcast_ref::<&str>() {
+            (AscString::new(message), info.location())
+        } else if let Some(message) = info.payload().downcast_ref::<String>() {
+            (AscString::new(message), info.location())
+        } else {
+            (AscString::new(info.to_string()), None)
+        };
+        let (file, line, column) = if let Some(location) = location {
+            (
+                Some(AscString::new(location.file())),
+                location.line(),
+                location.column(),
+            )
+        } else {
+            (None, 0, 0)
+        };
+
+        unsafe {
+            abort(
+                &*message,
+                file.as_ref().map(|f| f.as_asc_str()),
+                line,
+                column,
+            );
+        }
+    }));
+}
+
+#[link(wasm_import_module = "env")]
+extern "C" {
+    #[link_name = "abort"]
+    fn abort(message: &AscStr, file: Option<&AscStr>, line: u32, column: u32) -> !;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod abort;
 mod ffi;
 mod logger;
 
@@ -6,13 +7,14 @@ pub use log;
 /// Module containing required Wasm exports.
 #[doc(hidden)]
 pub mod exports {
-    use crate::logger;
+    use crate::{abort, logger};
 
     /// The Wasm start function. This gets set as the module's start function
     /// during post-processing of the Wasm blob, since there is currently no
     /// way to specify it in Rust at the moment.
     #[export_name = "__subgraph_start"]
     pub extern "C" fn start() {
+        abort::set_panic_hook();
         logger::init();
     }
 }


### PR DESCRIPTION
This PR implements a Rust panic hook that call's the host's runtime `abort` method.

### Test Plan

Like #7 this can't really be tested without a sample subgraph that will come in a later PR.