### PR TITLE
Sample subgraph

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,8 @@ edition = "2018"
 description = "Write subgraph mappings in Rust 🦀"
 license = "MIT OR Apache-2.0"
 
+[workspace]
+members = ["samples/*"]
+
 [dependencies]
 log = "0.4.11"

--- a/samples/deep-thought/Cargo.toml
+++ b/samples/deep-thought/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "deep-thought"
+version = "1.0.0"
+authors = ["Gnosis developers <developers@gnosis.io>"]
+edition = "2018"
+description = "Sample subgraph mappings written in Rust 🦀"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+subgraph = { path = "../.." }

--- a/samples/deep-thought/src/lib.rs
+++ b/samples/deep-thought/src/lib.rs
@@ -1,0 +1,12 @@
+use subgraph::log;
+
+#[export_name = "greatOnTurning"]
+pub extern "C" fn great_on_turning(event: *const ()) {
+    log::info!("[greatOnTurning] Hello from Rust 🦀!");
+    todo!("event pointer: {:?}", event);
+}
+
+#[export_name = "dayOfTheAnswer"]
+pub extern "C" fn day_of_the_answer(_: *const ()) {
+    todo!();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,10 @@ pub use log;
 #[doc(hidden)]
 pub mod exports {
     use crate::{abort, logger};
+    use std::{
+        alloc::{self, Layout},
+        mem,
+    };
 
     /// The Wasm start function. This gets set as the module's start function
     /// during post-processing of the Wasm blob, since there is currently no
@@ -16,5 +20,14 @@ pub mod exports {
     pub extern "C" fn start() {
         abort::set_panic_hook();
         logger::init();
+    }
+
+    /// A hook into the Rust memory allocation function so that the host may
+    /// allocate space for data to be sent to the mapping handlers.
+    #[export_name = "memory.allocate"]
+    pub extern "C" fn alloc(size: usize) -> *mut u8 {
+        // NOTE: Use the maximum wasm32 alignment by default.
+        const ALIGN: usize = mem::size_of::<u64>();
+        unsafe { alloc::alloc(Layout::from_size_align_unchecked(ALIGN, size)) }
     }
 }


### PR DESCRIPTION
This PR adds a sample subgraph. This also means we get to test the Rust bindings that were introduced in #7 and #8 :confetti_ball:.

### Test Plan

Unfortunately, deploying subgraphs is still very much a manual process. However, with some manual deployment steps, we can actually see the log message and the panic message in the Graph node logs :tada: :man_dancing:. 

```sh
# Build the sample subgraph targeting Wasm
cargo build -p deep-thought --target wasm32-unknown-unknown
# Manually add a Wasm `start` entry - there is no way to do this in Rust currently
wasm2wat target/wasm32-unknown-unknown/debug/deep_thought.wasm \
    | sed 's/(export "__subgraph_start" (func \(.*\)))/(start \1)/' \
    | wat2wasm - -o target/DeepThought.wasm
# Replace the sample Wasm mappings with the new one
cp target/DeepThought.wasm samples/deep-thought/DeepThought/DeepThought.wasm
# Run the deployment script
samples/deep-thought/deploy.sh
```

We can now check the graph node logs and see the log message from Rust along with the panic message (lots of stuff omitted from output to highlight the stuff that comes from Rust):
```
$ podman logs graphprotocol-graph-node
...
Sep 07 20:14:41.484 INFO [greatOnTurning] Hello from Rust 🦀!, [...]
...
Sep 07 20:14:41.491 ERRO [...] Mapping aborted at samples/deep-thought/src/lib.rs, line 6, column 5, with message: not yet implemented: event pointer: 0x112e50, [...]
```

For `docker-compose` setups, `s/podman/docker/g`.