### PR TITLE
Initial BigInt implementation

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,5 +1,21 @@
 //! Module containing FFI utilities for mapping Rust/C ABI to the AssemblyScript
 //! ABI.
+//!
+//! # `'host` Lifetime
+//!
+//! Special consideration should be taken with dealing with FFI functions that
+//! return values with a `'host` lifetime. The Graph host allocates memory to
+//! fill with return data in various functions. As of the this writing, these
+//! allocations are done in a host controlled arena allocator memory region and
+//! does not seem to provide a way to free this memory. Furthermore, additional
+//! allocations may cause the host to re-allocate a new region if it runs out of
+//! space in the arena allocator's memory region.
+//!
+//! # Safety
+//!
+//! Data from host functions that return references or pointers must be cloned
+//! into Rust-owned memory before any futher host allocations occur.
 
+pub mod array;
 mod buffer;
 pub mod string;

--- a/src/ffi/array.rs
+++ b/src/ffi/array.rs
@@ -1,10 +1,6 @@
 //! AssemblyScript array buffer and typed array implementations.
 
 use crate::ffi::buffer::{AscBuf, AscBuffer};
-use std::{
-    marker::PhantomData,
-    ops::{Bound, RangeBounds},
-};
 
 /// An owned AssemblyScript array buffer.
 pub type AscArrayBuffer = AscBuffer<u8, u64>;
@@ -34,45 +30,13 @@ impl<'a> AscUint8Array<'a> {
         }
     }
 
-    /// Returns a new sub-slice of the `u8` typed array with the specified
-    /// range.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the slice specifed by `range` is out of bounds of the typed
-    /// array.
-    pub fn slice(&self, range: impl RangeBounds<usize>) -> AscUint8Array<'_> {
-        let offset = self.offset
-            + match range.start_bound() {
-                Bound::Included(value) => *value,
-                Bound::Excluded(value) => value.saturating_add(1),
-                Bound::Unbounded => 0,
-            };
-        let len = {
-            let end = match range.end_bound() {
-                Bound::Included(value) => value.saturating_add(1),
-                Bound::Excluded(value) => *value,
-                Bound::Unbounded => 0,
-            };
-            end.checked_sub(offset)
-                .unwrap_or_else(|| panic!("slice index starts at {} but ends at {}", offset, end))
-        };
-
-        assert!(self.len >= offset + len);
-        Self {
-            buffer: &self.buffer,
-            offset,
-            len,
-        }
-    }
-
     /// Returns the `u8` typed array as a Rust slice.
     pub fn as_bytes(&self) -> &[u8] {
         &self.buffer.as_slice()[self.offset..(self.offset + self.len)]
     }
 
     /// Creates an owned AssemblyScript array buffer from the sliced bytes.
-    pub fn to_array_buffer(&self) -> AscArrayBuffer {
+    pub fn to_array_buffer(&self) -> Box<AscArrayBuffer> {
         AscArrayBuffer::new(self.as_bytes())
     }
 }

--- a/src/ffi/array.rs
+++ b/src/ffi/array.rs
@@ -40,3 +40,19 @@ impl<'a> AscUint8Array<'a> {
         AscArrayBuffer::new(self.as_bytes())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::alloc::Layout;
+
+    #[test]
+    fn array_buffer_layout() {
+        let buffer = AscArrayBuffer::new(b"\x00\x01\x02");
+        assert_eq!(buffer.len(), 3);
+        assert_eq!(
+            Layout::for_value(&*buffer),
+            Layout::new::<(usize, [u64; 0], [u8; 3])>().pad_to_align(),
+        );
+    }
+}

--- a/src/ffi/array.rs
+++ b/src/ffi/array.rs
@@ -1,0 +1,78 @@
+//! AssemblyScript array buffer and typed array implementations.
+
+use crate::ffi::buffer::{AscBuf, AscBuffer};
+use std::{
+    marker::PhantomData,
+    ops::{Bound, RangeBounds},
+};
+
+/// An owned AssemblyScript array buffer.
+pub type AscArrayBuffer = AscBuffer<u8, u64>;
+
+impl AscArrayBuffer {
+    /// Returns the the array buffer as a slice of bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+
+/// A `u8` typed array that slices an array buffer.
+#[repr(C)]
+pub struct AscUint8Array<'a> {
+    buffer: &'a AscBuf<u8, u64>,
+    offset: usize,
+    len: usize,
+}
+
+impl<'a> AscUint8Array<'a> {
+    /// Creates a typed array view over the entire specifed array buffer.
+    pub fn new(buffer: &'a AscBuf<u8, u64>) -> Self {
+        Self {
+            buffer,
+            offset: 0,
+            len: buffer.len(),
+        }
+    }
+
+    /// Returns a new sub-slice of the `u8` typed array with the specified
+    /// range.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the slice specifed by `range` is out of bounds of the typed
+    /// array.
+    pub fn slice(&self, range: impl RangeBounds<usize>) -> AscUint8Array<'_> {
+        let offset = self.offset
+            + match range.start_bound() {
+                Bound::Included(value) => *value,
+                Bound::Excluded(value) => value.saturating_add(1),
+                Bound::Unbounded => 0,
+            };
+        let len = {
+            let end = match range.end_bound() {
+                Bound::Included(value) => value.saturating_add(1),
+                Bound::Excluded(value) => *value,
+                Bound::Unbounded => 0,
+            };
+            end.checked_sub(offset)
+                .unwrap_or_else(|| panic!("slice index starts at {} but ends at {}", offset, end))
+        };
+
+        assert!(self.len >= offset + len);
+        Self {
+            buffer: &self.buffer,
+            offset,
+            len,
+        }
+    }
+
+    /// Returns the `u8` typed array as a Rust slice.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.buffer.as_slice()[self.offset..(self.offset + self.len)]
+    }
+
+    /// Creates an owned AssemblyScript array buffer from the sliced bytes.
+    pub fn to_array_buffer(&self) -> AscArrayBuffer {
+        AscArrayBuffer::new(self.as_bytes())
+    }
+}

--- a/src/ffi/string.rs
+++ b/src/ffi/string.rs
@@ -19,7 +19,6 @@ pub struct AscStr {
 
 impl AscStr {
     /// Converts the AssemblyScript string into a Rust `String`.
-    #[allow(unused)] // TODO(nlordell): Remove once it is used.
     pub fn to_string(&self) -> Result<String, FromUtf16Error> {
         String::from_utf16(&self.inner.as_slice())
     }
@@ -39,7 +38,7 @@ impl Debug for AscStr {
 
 /// An AssemblyScript string.
 pub struct AscString {
-    inner: Box<AscBuffer<u16>>,
+    inner: AscBuffer<u16>,
 }
 
 impl AscString {
@@ -54,7 +53,7 @@ impl AscString {
         };
         let inner = AscBuffer::new(&code_points);
 
-        AscString { inner }
+        Self { inner }
     }
 
     /// Returns a reference to a borrowed AssemblyScript string.
@@ -93,7 +92,7 @@ mod tests {
     #[test]
     fn string_layout() {
         let string = AscString::new("0123456");
-        assert_eq!(string.inner.as_slice().len(), 7);
+        assert_eq!(string.inner.len(), 7);
         assert_eq!(
             Layout::for_value(&*string.inner),
             Layout::new::<(usize, [u16; 7])>().pad_to_align(),

--- a/src/ffi/string.rs
+++ b/src/ffi/string.rs
@@ -38,7 +38,7 @@ impl Debug for AscStr {
 
 /// An AssemblyScript string.
 pub struct AscString {
-    inner: AscBuffer<u16>,
+    inner: Box<AscBuffer<u16>>,
 }
 
 impl AscString {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,10 @@
 mod abort;
 mod ffi;
 mod logger;
+mod num;
 
 pub use log;
+pub use num::bigint::BigInt;
 
 /// Module containing required Wasm exports.
 #[doc(hidden)]

--- a/src/num.rs
+++ b/src/num.rs
@@ -1,0 +1,3 @@
+//! Bindings to numerical subgraph types.
+
+pub mod bigint;

--- a/src/num/bigint.rs
+++ b/src/num/bigint.rs
@@ -33,7 +33,7 @@ impl BigInt {
         }
     }
 
-    /// Creates a `BigInt` instance from unsigned little endian bytes.
+    /// Creates a `BigInt` instance from signed little endian bytes.
     pub fn from_signed_bytes_le(bytes: impl AsRef<[u8]>) -> Self {
         Self {
             inner: AscArrayBuffer::new(bytes.as_ref()),

--- a/src/num/bigint.rs
+++ b/src/num/bigint.rs
@@ -1,0 +1,109 @@
+//! Subgraph arbitrary precision integer implementation.
+
+use crate::ffi::{
+    array::{AscArrayBuffer, AscUint8Array},
+    string::AscStr,
+};
+use std::{
+    fmt::{self, Debug, Display, Formatter},
+    ops::Add,
+};
+
+/// A arbitrary precision big integer. This uses the host big integer
+/// implementation through the provided import functions.
+///
+/// `BitInt` is represented on the host as its little-endian bytes.
+pub struct BigInt {
+    inner: AscArrayBuffer,
+}
+
+impl BigInt {
+    /// Add the specified `BigInt` to `self`, returning the result.
+    pub fn add(&self, rhs: &Self) -> Self {
+        let x = self.as_host();
+        let y = rhs.as_host();
+
+        // SAFETY: The host allocation gets cloned to an owned array buffer.
+        let inner = unsafe { plus(x, y).to_array_buffer() };
+
+        Self { inner }
+    }
+
+    /// Returns a number representing the sign of `self`.
+    /// - `0` if the number is 0
+    /// - `1` if the number is positive
+    /// - `-1` if the number is negative
+    pub fn signum(&self) -> i32 {
+        let bytes = self.inner.as_bytes();
+
+        // NOTE: In LE, the most significant bit, which contains the sign
+        // information is the last byte.
+        if bytes.iter().all(|b| *b == 0) {
+            0
+        } else {
+            let last_byte = bytes.last().copied().unwrap_or(0);
+            (last_byte as i8).signum() as _
+        }
+    }
+
+    fn as_host(&self) -> HostBigInt<'_> {
+        HostBigInt::new(&self.inner)
+    }
+}
+
+impl Debug for BigInt {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl Display for BigInt {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let x = self.as_host();
+        let s = {
+            let asc_str = unsafe { bigIntToString(x) };
+            asc_str
+                .to_string()
+                .expect("integer strings are always valid UTF-16")
+        };
+
+        f.pad_integral(self.signum() >= 0, "", &s)
+    }
+}
+
+impl<'a> Add for &'a BigInt {
+    type Output = BigInt;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        self.add(rhs)
+    }
+}
+
+macro_rules! from_primitive {
+    ($($t:ty),* $(,)?) => {$(
+        impl From<$t> for BigInt {
+            fn from(x: $t) -> Self {
+                Self {
+                    inner: AscArrayBuffer::new(x.to_le_bytes()),
+                }
+            }
+        }
+    )*};
+}
+
+from_primitive! {
+    i8, i16, i32, i64, i128, isize,
+    u8, u16, u32, u64, u128, usize,
+}
+
+/// The host `BigInt` type.
+type HostBigInt<'a> = AscUint8Array<'a>;
+
+#[link(wasm_import_module = "index")]
+extern "C" {
+    #[link_name = "bigInt.plus"]
+    fn plus<'host>(x: HostBigInt, y: HostBigInt) -> HostBigInt<'host>;
+
+    #[link_name = "typeConversion.bigIntToString"]
+    fn bigIntToString(x: HostBigInt) -> &AscStr;
+}


### PR DESCRIPTION
This PR introduce the `BigInt` type with addition and formatting implemented.

### Test Plan

New unit tests for Rust implemented components. A strategy for unit testing with mocked host methods is coming in a follow-up PR.